### PR TITLE
editor for tig

### DIFF
--- a/rc/env/overrides.env
+++ b/rc/env/overrides.env
@@ -3,3 +3,4 @@ PATH=$kak_opt_connect_path/paths/aliases:$kak_opt_connect_path/paths/commands:$P
 SHELL=$kak_client_env_SHELL
 VISUAL=edit
 EDITOR=edit
+export GIT_EDITOR=edit


### PR DESCRIPTION
It turns out that tig doesn't respect `$EDITOR` env var, at least I wasn't able to invoke kak with its `e` command within connect-terminal. Exporting `GIT_EDITOR` makes tig to invoke internal edit command.