### PR TITLE
edit: shift 2 if +line(:column) is given

### DIFF
--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -3,21 +3,21 @@
 commands=''
 while test $# -gt 0; do
   file=$(realpath "$1")
-  shift
   # Optional coordinates
   case "$2" in
     +*:*)
       line=${2#+}; line=${line%:*}
       column=${2#*:}
-      shift
+      shift 2
       commands="edit %{$file} $line $column; $commands"
       ;;
     +*)
       line=${2#+}
-      shift
+      shift 2
       commands="edit %{$file} $line; $commands"
       ;;
     *)
+      shift
       commands="edit %{$file}; $commands"
       ;;
   esac


### PR DESCRIPTION
This PR fixes an issue, that +line(:column) is not recognized whith edit command. For example: Running `edit $(it) +10:2` in a connected terminal opens the current buffile and the new file "+10:2".