### PR TITLE
added an option connect_environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ require-module connect-dolphin
 map global normal <c-t> ': connect-terminal<ret>'
 ```
 
+By setting the option `connect_environment` you can specify commands that
+are run before the shell is executed. This might be useful, if you want to
+change or export environment variables:
+
+``` kak
+set-option global connect_environment %{
+  GIT_EDITOR='kak -c $KAKOUNE_SESSION'
+  export LYEDITOR='edit %(file)s +%(line)s:%(column)s'
+}
+```
+
 ## Kakoune commands
 
 - [`:connect-terminal`] | [`:t`]

--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -1,16 +1,18 @@
 declare-option -hidden str connect_path %sh(dirname "$kak_source")
+declare-option str connect_environment
 
 provide-module connect %{
   define-command connect-terminal -params .. -command-completion -docstring 'Connect a terminal' %{
     terminal sh -c %{
-      kak_opt_connect_path=$1 kak_session=$2 kak_client=$3 kak_client_env_SHELL=$4
+      kak_opt_connect_path=$1 kak_opt_connect_environment=$2 kak_session=$3 kak_client=$4 kak_client_env_SHELL=$5
       . "$kak_opt_connect_path/env/default.env"
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
-      shift 4
+      eval "$kak_opt_connect_environment"
+      shift 5
       "${@:-$SHELL}"
-    } -- %opt{connect_path} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
+    } -- %opt{connect_path} %opt{connect_environment} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
   }
   define-command connect-shell -params 1.. -shell-completion -docstring 'Connect a shell' %{
     nop %sh{
@@ -19,6 +21,7 @@ provide-module connect %{
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
+      eval "$kak_opt_connect_environment"
       setsid sh -c "$@" < /dev/null > /dev/null 2>&1 &
     }
   }


### PR DESCRIPTION
The option connect_envrionment is evaluated just after the .env files,
so that the user can change and set environment variables in the connected
shell through this option.