### PR TITLE
add ability to use different terminal commands

### DIFF
--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -2,19 +2,22 @@ declare-option -hidden str connect_path %sh(dirname "$kak_source")
 declare-option str connect_environment
 
 provide-module connect %{
-  define-command connect-terminal -params .. -command-completion -docstring 'Connect a terminal' %{
-    terminal sh -c %{
+  define-command connect-command -params 1.. -command-completion -docstring 'connect-command <command> [<program>] [<arguments]: use <command> as the terminal command' %{
+    %arg{1} sh -c %{
       kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_session=$4 kak_client=$5 kak_client_env_SHELL=$6
       . "$kak_opt_connect_path/env/default.env"
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
       eval "$kak_opt_connect_environment"
-      shift 6
+      shift 7
       "${@:-$SHELL}"
     } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
   }
-  define-command connect-shell -params 1.. -shell-completion -docstring 'Connect a shell' %{
+  define-command connect-terminal -params .. -command-completion -docstring 'connect-terminal [<program>] [<arguments>]: connect a terminal' %{
+      connect-command terminal %arg{@}
+  }
+  define-command connect-shell -params 1.. -shell-completion -docstring 'connect-shell <program> [<arguments>]: connect a shell' %{
     nop %sh{
       # kak_opt_prelude kak_opt_connect_path kak_opt_connect_environment kak_session kak_client kak_client_env_SHELL
       . "$kak_opt_connect_path/env/default.env"

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -7,6 +7,7 @@
 wait=false
 case "$1" in
   -wait) wait=true; shift ;;
+  --) shift ;;
 esac
 
 commands=''


### PR DESCRIPTION
Most editor commands accept `--` as a flag to denote that no further flags
should be processed.
This allows opening files named like flags (e.g. `-wait`).

----

A user might have specialized terminal-like commands to open terminals with
certain properties (e.g. terminal-on-left, floating-terminal).
This allows a user to use those alternative commands instead of only
supporting the terminal command.

This patch also changes to docstrings to document the arguments similar
to other kakoune commands.

