### PR TITLE
Adds the ability to focus kakoune on `open`

### DIFF
--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -1,18 +1,20 @@
 declare-option -hidden str connect_path %sh(dirname "$kak_source")
 declare-option str connect_environment
+declare-option str connect_focus 0
 
 provide-module connect %{
   define-command connect-terminal -params .. -command-completion -docstring 'Connect a terminal' %{
     terminal sh -c %{
-      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_session=$4 kak_client=$5 kak_client_env_SHELL=$6
+      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_opt_connect_focus=$4 kak_session=$5 kak_client=$6 kak_client_env_SHELL=$7
       . "$kak_opt_connect_path/env/default.env"
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
+      export kak_opt_connect_focus
       eval "$kak_opt_connect_environment"
-      shift 6
+      shift 7
       "${@:-$SHELL}"
-    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
+    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %opt{connect_focus} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
   }
   define-command connect-shell -params 1.. -shell-completion -docstring 'Connect a shell' %{
     nop %sh{

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -40,6 +40,16 @@ kak_quoted_regex=$(kak_escape "$regex")
 
 send "$commands"
 
+if [[ $kak_opt_connect_focus -eq 1 ]]; then
+    if [[ -z $TMUX ]]; then
+        i3-msg "[title = \"${KAKOUNE_CLIENT}\"] focus"
+    else
+        # This totally does **not** work, because we don't know in which
+        # direction the kakoune pane is.
+        tmux select-pane -L
+    fi
+fi
+
 if test "$wait" = true; then
   state=$(mktemp -d)
   trap 'rm -Rf "$state"' EXIT


### PR DESCRIPTION
I use connect mostly with `nnn` as a sort of project manager.  More often than not, after opening a file in `nnn`, I want focus to return to kakoune.  This patch adds that ability.

When the option `connect_focus` is set, `edit` will focus the window containing kakoune.  This works reliably with i3, because both kakoune and i3 provide good information and mechanisms for making it happen.  It works with tmux **if** the user doesn't move panes around; this limitation is due to the fact that there's no way to focus a pane by name, and wouldn't even if it could because kakoune doesn't set a pane title. However, the default behavior -- of opening a tmux pane to the right -- is assumed and control is return to the pane to the left.  There is no functionality for any other window manager.

The script tries to do the right thing: it only does its thing if the `connect_focus` option is set; then it tries to detect if it is running in tmux, and if so, tries to return focus that way; then if not, it tries to do it with i3.

Example use:
```
: set-option buffer connect_focus 1
: connect-terminal sh -c '(NNN_OPENER=edit nnn)'
```
select a file in `nnn` and hit <ret>.