### PR TITLE
Suggested changes

### DIFF
--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -5,16 +5,15 @@ declare-option str connect_focus 0
 provide-module connect %{
   define-command connect-terminal -params .. -command-completion -docstring 'Connect a terminal' %{
     terminal sh -c %{
-      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_opt_connect_focus=$4 kak_session=$5 kak_client=$6 kak_client_env_SHELL=$7
+      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_session=$4 kak_client=$5 kak_client_env_SHELL=$6
       . "$kak_opt_connect_path/env/default.env"
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
-      . "$kak_opt_connect_path/env/behavior.env"
       eval "$kak_opt_connect_environment"
-      shift 7
+      shift 6
       "${@:-$SHELL}"
-    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %opt{connect_focus} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
+    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
   }
   define-command connect-shell -params 1.. -shell-completion -docstring 'Connect a shell' %{
     nop %sh{

--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -1,18 +1,20 @@
 declare-option -hidden str connect_path %sh(dirname "$kak_source")
 declare-option str connect_environment
+declare-option str connect_focus 0
 
 provide-module connect %{
   define-command connect-terminal -params .. -command-completion -docstring 'Connect a terminal' %{
     terminal sh -c %{
-      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_session=$4 kak_client=$5 kak_client_env_SHELL=$6
+      kak_opt_prelude=$1 kak_opt_connect_path=$2 kak_opt_connect_environment=$3 kak_opt_connect_focus=$4 kak_session=$5 kak_client=$6 kak_client_env_SHELL=$7
       . "$kak_opt_connect_path/env/default.env"
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
+      export kak_opt_connect_focus
       eval "$kak_opt_connect_environment"
-      shift 6
+      shift 7
       "${@:-$SHELL}"
-    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
+    } -- %opt{prelude} %opt{connect_path} %opt{connect_environment} %opt{connect_focus} %val{session} %val{client} %val{client_env_SHELL} %arg{@}
   }
   define-command connect-shell -params 1.. -shell-completion -docstring 'Connect a shell' %{
     nop %sh{

--- a/rc/connect.kak
+++ b/rc/connect.kak
@@ -10,7 +10,7 @@ provide-module connect %{
       . "$kak_opt_connect_path/env/overrides.env"
       . "$kak_opt_connect_path/env/kakoune.env"
       . "$kak_opt_connect_path/env/git.env"
-      export kak_opt_connect_focus
+      . "$kak_opt_connect_path/env/behavior.env"
       eval "$kak_opt_connect_environment"
       shift 7
       "${@:-$SHELL}"

--- a/rc/env/behavior.env
+++ b/rc/env/behavior.env
@@ -1,1 +1,0 @@
-export KAK_CONNECT_RETURN_FOCUS=$kak_opt_connect_focus

--- a/rc/env/behavior.env
+++ b/rc/env/behavior.env
@@ -1,0 +1,1 @@
+export KAK_CONNECT_RETURN_FOCUS=$kak_opt_connect_focus

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -40,6 +40,16 @@ kak_quoted_regex=$(kak_escape "$regex")
 
 send "$commands"
 
+if [[ $kak_opt_connect_focus -eq 1 ]]; then
+    if [[ -z $TMUX ]]; then
+        i3-msg "[title = \"${KAKOUNE_CLIENT}\"] focus"
+    else
+        # This totally does **not** work, because we don't know in which
+        # direction the kakoune pane is.
+        tmux select-pane -L
+    fi
+fi
+
 if test "$wait" = true; then
   state=$(mktemp -d)
   trap 'rm -Rf "$state"' EXIT

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -35,8 +35,6 @@ while test $# -gt 0; do
   esac
   regex="${regex}|\\Q${file}\\E"
 done
-# Focus back the client on open.
-commands="$commands; focus"
 regex=${regex#|}
 kak_quoted_regex=$(kak_escape "$regex")
 

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -38,12 +38,9 @@ done
 regex=${regex#|}
 kak_quoted_regex=$(kak_escape "$regex")
 
-[[ $KAK_CONNECT_RETURN_FOCUS -eq 1 && -z $TMUX ]] && commands="$commands; focus"
+[[ $(get '%opt{connect_focus}') -eq 1 ]] && commands="$commands; focus"
 
 send "$commands"
-
-# This is unreliable, because we don't know in which direction the kakoune pane lies.
-[[ $KAK_CONNECT_RETURN_FOCUS -eq 1 && -n $TMUX ]] && tmux select-pane -L
 
 if test "$wait" = true; then
   state=$(mktemp -d)

--- a/rc/paths/commands/edit
+++ b/rc/paths/commands/edit
@@ -38,17 +38,12 @@ done
 regex=${regex#|}
 kak_quoted_regex=$(kak_escape "$regex")
 
+[[ $KAK_CONNECT_RETURN_FOCUS -eq 1 && -z $TMUX ]] && commands="$commands; focus"
+
 send "$commands"
 
-if [[ $kak_opt_connect_focus -eq 1 ]]; then
-    if [[ -z $TMUX ]]; then
-        i3-msg "[title = \"${KAKOUNE_CLIENT}\"] focus"
-    else
-        # This totally does **not** work, because we don't know in which
-        # direction the kakoune pane is.
-        tmux select-pane -L
-    fi
-fi
+# This is unreliable, because we don't know in which direction the kakoune pane lies.
+[[ $KAK_CONNECT_RETURN_FOCUS -eq 1 && -n $TMUX ]] && tmux select-pane -L
 
 if test "$wait" = true; then
   state=$(mktemp -d)


### PR DESCRIPTION
`focus` indeed works with both the window manager and tmux, so I removed the logic that switched on the environment; it's controlled now only by the user setting and the work is done by `focus`.

The `get` trick works well, so I removed all of the hacking around to get at the option and used that directly.

The difference from master now boils down to the fact that the *default* behavior is the same as pre-patch (focus is disabled by default), but can be enabled by the user setting an option.  Again, the use case I see for this is per-buffer-type configuration.