### PR TITLE
Fixed quoting for :ls and rofi/wofi module

### DIFF
--- a/rc/connect/commands/:ls
+++ b/rc/connect/commands/:ls
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # List buffers
-kak_quoted_buflist=$(:get %val{buflist})
+kak_quoted_buflist=$(:get -quoting shell %val{buflist})
 eval "set -- $kak_quoted_buflist"
 printf '%s\n' "$@"

--- a/rc/connect/modules/rofi/commands/:rofi-buffers
+++ b/rc/connect/modules/rofi/commands/:rofi-buffers
@@ -3,11 +3,13 @@
 # Rofi
 # https://github.com/davatorium/rofi
 
+. "$KAKOUNE_PRELUDE"
+
 # Arguments
 pattern=$1
 
-:buffer $(
+:buffer "$(kak_escape "$(
   :ls |
   grep -F "$pattern" |
   rofi -dmenu -i -p 'Open buffers'
-)
+)")"

--- a/rc/connect/modules/rofi/commands/:rofi-files
+++ b/rc/connect/modules/rofi/commands/:rofi-files
@@ -6,7 +6,9 @@
 # Dependencies:
 # – fd (https://github.com/sharkdp/fd)
 
-:edit $(
+. "$KAKOUNE_PRELUDE"
+
+:edit "$(kak_escape "$(
   fd --type file . "$@" |
   rofi -dmenu -i -p 'Open files'
-)
+)")"

--- a/rc/connect/modules/wofi/commands/:wofi-buffers
+++ b/rc/connect/modules/wofi/commands/:wofi-buffers
@@ -3,11 +3,13 @@
 # Wofi
 # https://hg.sr.ht/~scoopta/wofi
 
+. "$KAKOUNE_PRELUDE"
+
 # Arguments
 pattern=$1
 
-:buffer $(
+:buffer "$(kak_escape "$(
   :ls |
   grep -F "$pattern" |
   wofi --dmenu --prompt 'Open buffers'
-)
+)")"

--- a/rc/connect/modules/wofi/commands/:wofi-files
+++ b/rc/connect/modules/wofi/commands/:wofi-files
@@ -6,7 +6,9 @@
 # Dependencies:
 # – fd (https://github.com/sharkdp/fd)
 
-:edit $(
+. "$KAKOUNE_PRELUDE"
+
+:edit "$(kak_escape "$(
   fd --type file . "$@" |
   wofi --dmenu --prompt 'Open files'
-)
+)")"


### PR DESCRIPTION
`rofi-buffers` wouldn't work with buffers with spaces or similar. Pretty often: `*man whatever*`.

I have not checked the whole codebase for similar issues that require `-quoting shell` or quotes in front of a `:command`.