### PR TITLE
Makefile: create .local/share/applications if it doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 	curl -sSL https://github.com/mawww/kakoune/raw/master/doc/kakoune_logo.svg --create-dirs -o ~/.local/share/icons/hicolor/scalable/apps/kakoune.svg
-	mkdir -p ~/.local/bin ~/.local/share/kak
+	mkdir -p ~/.local/bin ~/.local/share/kak ~/.local/share/applications
 	ln -sf "${PWD}/bin/kak-shell" "${PWD}/bin/kak-desktop" ~/.local/bin
 	ln -sf "${PWD}/share/applications/kakoune-connect.desktop" ~/.local/share/applications
 	ln -sf "${PWD}/share/kak/connect" ~/.local/share/kak


### PR DESCRIPTION
If the directory doesn't exist, the line
```
ln -sf "${PWD}/share/applications/kakoune-connect.desktop" ~/.local/share/applications
```
will create a link named `applications` instead of a link *in* `applications`.