### PR TITLE
Render kakoune.cr link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,4 +298,6 @@ Available variables are:
 
 # Alternatives
 
+- [kakoune.cr]
+
 [kakoune.cr]: https://github.com/alexherbo2/kakoune.cr


### PR DESCRIPTION
The link to kakoune.cr is currently not visible in the README. This line will render it so that it's visible on github