### PR TITLE
Fix: :edit-search does not fail when 'jump-to' line ends with a space

### DIFF
--- a/rc/connect/commands/:edit-search
+++ b/rc/connect/commands/:edit-search
@@ -8,7 +8,7 @@
 #
 # Input: <file>:<line>:<column>:<text>
 # Output: <file>␤<line>␤<column>
-select_each_line='<a-s>_'
+select_each_line='<a-s>_x'
 select_search_fields='s^(.+?):(\d+):(\d+):(.+?)$<ret>'
 save_selections='Z'
 select_file_save_and_restore='1s<ret>"fZz'


### PR DESCRIPTION
Any "jump-to" line that ends with a whitespace is not matched by a regex because of a '_' command that strips all the whitespace.

Test case:

`echo '/etc/passwd:1:1:this is some text ' | :edit-search` fails.
`echo '/etc/passwd:1:1:this is some text' | :edit-search` succeeds.

`x` selecting a whole line solves an issue. **I'm not sure though if it does not break `:edit-search` in some way.** Thanks a lot for a review.  